### PR TITLE
Minor fixes for GitHub Action workflow to build + push Docker image

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -3,6 +3,7 @@ name: Publish Docker image for PrepareAA
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   push_to_registry:

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -12,18 +12,16 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
-
+      - name: Log in to Quay.io
+        uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: quay.io
+          username: ${{ secrets.QUAYIO_CIRCDNA_USERNAME }}
+          password: ${{ secrets.QUAYIO_CIRCDNA_PASSWORD }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        uses: docker/build-push-action@v4
         with:
-          context: .
-          file: ../../modules/local/ampliconsuite/Dockerfile
+          file: modules/local/ampliconsuite/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: "quay.io/nf-core/prepareaa:latest"


### PR DESCRIPTION
Fixes for the Docker image build + push action that runs on release.

New image URL is https://quay.io/repository/nf-core/prepareaa