### PR TITLE
Quick Version Release 1.0.4 - Pipeline issue arose in 1.0.3 where only one sample was processed 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.4 - [2023-06-26]
+
+### `Added`
+
+### `Fixed`
+
+- Bug that the pipeline only runs with one sample when Picard Markduplicates is used
+
+### `Dependencies`
+
+### `Deprecated`
+
 ## v1.0.3 - [2023-05-26]
 
 ### `Added`

--- a/nextflow.config
+++ b/nextflow.config
@@ -261,7 +261,7 @@ manifest {
     description     = """Pipeline for the identification of circular DNAs"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=22.10.1'
-    version         = '1.0.3'
+    version = '1.0.4'
     doi             = '10.5281/zenodo.7712010'
 }
 

--- a/workflows/circdna.nf
+++ b/workflows/circdna.nf
@@ -23,7 +23,7 @@ if (!(params.input_format == "FASTQ" | params.input_format == "BAM")) {
 }
 
 // Modify fasta channel to include meta data
-ch_fasta_meta = ch_fasta.map{ it -> [[id:it[0].baseName], it] }
+ch_fasta_meta = ch_fasta.map{ it -> [[id:it[0].baseName], it] }.collect()
 
 branch = params.circle_identifier.split(",")
 run_circexplorer2 = ("circexplorer2" in branch)


### PR DESCRIPTION
# Version Release 1.0.4

## v1.0.4 - [2023-06-26]

### `Added`

### `Fixed`

- Bug that the pipeline only runs with one sample when Picard Markduplicates is used

### `Dependencies`

### `Deprecated`

<!--
# nf-core/circdna pull request

Many thanks for contributing to nf-core/circdna!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/circdna/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/circdna/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/circdna _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
